### PR TITLE
make taxburst_prep.py more robust

### DIFF
--- a/bin/taxburst_prep.py
+++ b/bin/taxburst_prep.py
@@ -25,7 +25,8 @@ def sanitize_taxonomy_for_taxburst(out):
     Ensure Taxburst/Krona never sees empty taxonomy names.
     Fills blanks with deterministic placeholders using parent context.
     """
-    # Normalize whitespace first
+    # Strip leading/trailing whitespace from every taxonomy rank value so that
+    # blank-padded fields (common in CSV exports) are treated as truly empty
     for k in RANKS_IN:
         v = out.get(k, "")
         out[k] = v.strip() if isinstance(v, str) else ""


### PR DESCRIPTION
In this PR, we make `taxburst_prep.py` more robust when input taxonomy tables contain missing rank values (ex. blank superkingdom, phylum, or other lineage fields).

Taxburst’s Krona parser/checks can fail on incomplete taxonomy rows with assertions such as:
* `AssertionError (empty lineage during parsing)`
* `AssertionError: duplicate name: (empty node names during structure validation)`

These failures occur when one or more taxonomy rank fields are blank in the generated Krona TSV.

To fix this:

1. Added a taxonomy sanitization step before writing Taxburst input.
2. Normalizes whitespace-only values.
3. Ensures superkingdom is never empty (fills with unclassified).
4. Fills missing lower ranks with deterministic, non-empty placeholders (rank-specific, with parent context), so Taxburst never receives empty names. 

I tested with the 16S subworkflow, now going to test with the metagenomic classification subworkflow to make sure this change doesnt affect anything there.