### PR TITLE
update the bioconda recipe for somatem

### DIFF
--- a/bin/somatem
+++ b/bin/somatem
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIPELINE_DIR="@@PIPELINE_DIR@@"
+
+show_help() {
+    cat <<'EOF'
+somatem: launch the Somatem Nextflow pipeline
+
+Usage:
+  somatem [Nextflow pipeline options]
+
+Examples:
+  somatem -params-file assets/16S_params.yml
+  somatem -params-file assets/custom_metadata.yaml
+  somatem --input samplesheet.csv --outdir results -profile conda
+  somatem -profile docker --input samplesheet.csv --outdir results
+
+Notes:
+  - Relative paths passed to -params-file or --params-file that match files
+    inside the installed Somatem pipeline will be resolved automatically.
+  - Any other arguments are passed directly to:
+      nextflow run <pipeline>/main.nf
+
+Support:
+  - If you run into any issues, please feel free to reach out.
+  - Repository:
+      https://github.com/treangenlab/Somatem
+  - Wiki:
+      https://github.com/treangenlab/Somatem/wiki
+  - You can look through the GitHub wiki pages for documentation on the
+    major subworkflows within Somatem.
+
+Help:
+  somatem -h
+  somatem --help
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    show_help
+    exit 0
+fi
+
+args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -params-file|--params-file)
+            shift
+            pf="$1"
+            if [[ "$pf" != /* && -f "${PIPELINE_DIR}/${pf}" ]]; then
+                args+=("-params-file" "${PIPELINE_DIR}/${pf}")
+            else
+                args+=("-params-file" "$pf")
+            fi
+            ;;
+        *)
+            args+=("$1")
+            ;;
+    esac
+    shift
+done
+
+exec nextflow run "${PIPELINE_DIR}/main.nf" "${args[@]}"

--- a/recipes/somatem/build.sh
+++ b/recipes/somatem/build.sh
@@ -1,80 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir -p "${PREFIX}/share/${PKG_NAME}"
+PIPELINE_DIR="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
+
 mkdir -p "${PREFIX}/bin"
+mkdir -p "${PIPELINE_DIR}"
 
-# Copy the full pipeline repository into the Conda package share dir
-cp -a . "${PREFIX}/share/${PKG_NAME}/src_tmp"
-cp -a "${PREFIX}/share/${PKG_NAME}/src_tmp"/. "${PREFIX}/share/${PKG_NAME}/"
-rm -rf "${PREFIX}/share/${PKG_NAME}/src_tmp"
-
-# Create launcher
-cat > "${PREFIX}/bin/${PKG_NAME}" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-PIPELINE_DIR="${PREFIX}/share/${PKG_NAME}"
-
-show_help() {
-    cat <<'EOM'
-somatem: launch the Somatem Nextflow pipeline
-
-Usage:
-  somatem [Nextflow pipeline options]
-
-Examples:
-  somatem -params-file assets/16S_params.yml
-  somatem -params-file assets/custom_metadata.yaml
-  somatem --input samplesheet.csv --outdir results -profile conda
-  somatem -profile docker --input samplesheet.csv --outdir results
-
-Notes:
-  - Relative paths passed to -params-file or --params-file that match files
-    inside the installed Somatem pipeline will be resolved automatically.
-  - Any other arguments are passed directly to:
-      nextflow run <pipeline>/main.nf
-
-Support:
-  - If you run into any issues, please feel free to reach out.
-  - Repository:
-      https://github.com/treangenlab/Somatem
-  - Wiki:
-      https://github.com/treangenlab/Somatem/wiki
-  - You can look through the GitHub wiki pages for documentation on the
-    major subworkflows within Somatem.
-
-Help:
-  somatem -h
-  somatem --help
-EOM
-}
-
-if [[ "\${1:-}" == "-h" || "\${1:-}" == "--help" ]]; then
-    show_help
-    exit 0
-fi
-
-args=()
-while [[ \$# -gt 0 ]]; do
-    case "\$1" in
-        -params-file|--params-file)
-            shift
-            pf="\$1"
-            if [[ "\$pf" != /* && -f "\${PIPELINE_DIR}/\${pf}" ]]; then
-                args+=("-params-file" "\${PIPELINE_DIR}/\${pf}")
-            else
-                args+=("-params-file" "\$pf")
-            fi
-            ;;
-        *)
-            args+=("\$1")
-            ;;
-    esac
-    shift
-done
-
-exec nextflow run "\${PIPELINE_DIR}/main.nf" "\${args[@]}"
-EOF
-
+cp bin/somatem "${PREFIX}/bin/${PKG_NAME}"
 chmod +x "${PREFIX}/bin/${PKG_NAME}"
+
+sed -i "s|@@PIPELINE_DIR@@|${PIPELINE_DIR}|g" "${PREFIX}/bin/${PKG_NAME}"
+
+cp -r assets "${PIPELINE_DIR}/"
+cp -r bin "${PIPELINE_DIR}/"
+cp -r conf "${PIPELINE_DIR}/"
+cp -r docs "${PIPELINE_DIR}/"
+cp -r modules "${PIPELINE_DIR}/"
+cp -r subworkflows "${PIPELINE_DIR}/"
+cp -r workflows "${PIPELINE_DIR}/"
+cp -r tests "${PIPELINE_DIR}/"
+
+cp CITATIONS.md "${PIPELINE_DIR}/"
+cp LICENSE "${PIPELINE_DIR}/"
+cp README.md "${PIPELINE_DIR}/"
+cp main.nf "${PIPELINE_DIR}/"
+cp modules.json "${PIPELINE_DIR}/"
+cp nextflow.config "${PIPELINE_DIR}/"
+cp nf-test.config "${PIPELINE_DIR}/"

--- a/recipes/somatem/meta.yaml
+++ b/recipes/somatem/meta.yaml
@@ -22,8 +22,9 @@ requirements:
 test:
   commands:
     - somatem --help
-    - test -f "${PREFIX}/share/{{ name }}/main.nf"
-    - test -f "${PREFIX}/share/{{ name }}/nextflow.config"
+    - test -f "${PREFIX}/share/{{ name }}-{{ version }}/main.nf"
+    - test -f "${PREFIX}/share/{{ name }}-{{ version }}/nextflow.config"
+    - test -f "${PREFIX}/bin/{{ name }}"
 
 about:
   home: https://github.com/treangenlab/Somatem


### PR DESCRIPTION
Updated the recipe to follow the Bactopia-style pattern.

The `somatem` launcher now lives in the upstream repository as `bin/somatem`, and the Bioconda `build.sh` now installs that launcher plus the pipeline files into the Conda prefix instead of generating the launcher during package build.

This is essentially a duplicate of #97 but updating the launcher format with recommendations from @bkille 