### PR TITLE
fixing the config paths for backward compatibility (all relative to `nextflow.config` now)

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -159,7 +159,7 @@ params {
 }
 
 // Load base.config by default for all pipelines
-includeConfig "${projectDir}/conf/base.config" // ensure config is loaded from the installed pipeline root
+includeConfig 'conf/base.config'
 
 // -------------------------
 // Profiles
@@ -274,8 +274,8 @@ profiles {
         apptainer.runOptions    = '--nv'
         singularity.runOptions  = '--nv'
     }
-    test      { includeConfig "${projectDir}/conf/test.config" }      // resolve bundled test config from installed pipeline root
-    test_full { includeConfig "${projectDir}/conf/test_full.config" } // resolve bundled test config from installed pipeline root
+    test      { includeConfig 'conf/test.config' }      
+    test_full { includeConfig 'conf/test_full.config' } 
 }
 
 // Load nf-core custom profiles from different institutions
@@ -299,7 +299,7 @@ singularity.registry  = 'quay.io'
 charliecloud.registry = 'quay.io'
 
 // Load igenomes.config if required
-includeConfig !params.igenomes_ignore ? "${projectDir}/conf/igenomes.config" : "${projectDir}/conf/igenomes_ignored.config" // resolve bundled config files from installed pipeline root
+includeConfig !params.igenomes_ignore ? 'conf/igenomes.config' : 'conf/igenomes_ignored.config'
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.
@@ -375,4 +375,4 @@ manifest {
 
 
 // Load modules.config for DSL2 module specific options
-includeConfig "${projectDir}/conf/modules.config" // ensure module config is loaded from the installed pipeline root
+includeConfig 'conf/modules.config'


### PR DESCRIPTION
- `nextflow run test-modules/..` should work after this fix

reverting config path changes made in 10ad6e4 (#97)
 - `includeConfig 'conf/base.config' should work for bioconda/somatem since "relative paths resolve against the config file location"
 - left the `${projectDir}/` prefix in place for the `input` param only
 - testing: works for 16S in bioconda run

Note:
- Merging this partial work on #109 
- Need this backward compatible change for other branches to be tested and I didn't want to fork > 2 branches away from main. 