### PR TITLE
update isolate subwrkflw, etosha hybrid assem pass

### DIFF
--- a/assets/samplesheets/isolate_samples.csv
+++ b/assets/samplesheets/isolate_samples.csv
@@ -1,0 +1,2 @@
+sample,long_reads,short_reads_1,short_reads_2,expected_genome_size,species
+FFI_BCgr,/home/agm/Documents/somatem/assets/data/isolate/SRR24519620.fastq.gz,/home/agm/Documents/somatem/assets/data/isolate/SRR24519621_1.fastq.gz,/home/agm/Documents/somatem/assets/data/isolate/SRR24519621_2.fastq.gz,5.4m,Bacillus_cereus

--- a/bin/somatem
+++ b/bin/somatem
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
 NEXTFLOW_BIN="nextflow"
 if [[ -x "${SCRIPT_DIR}/nextflow" ]]; then
     NEXTFLOW_BIN="${SCRIPT_DIR}/nextflow"

--- a/bin/somatem
+++ b/bin/somatem
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
-SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 NEXTFLOW_BIN="nextflow"
 if [[ -x "${SCRIPT_DIR}/nextflow" ]]; then
     NEXTFLOW_BIN="${SCRIPT_DIR}/nextflow"

--- a/bin/somatem_report.py
+++ b/bin/somatem_report.py
@@ -92,6 +92,21 @@ WORKFLOW_COPY = {
         ],
         "accent": "#be123c",
     },
+    "isolate_analysis": {
+        "title": "Isolate analysis",
+        "summary": (
+            "This report summarizes long-read-first bacterial isolate assembly, optional hybrid polishing, "
+            "read classification, assembly quality assessment, genome annotation, and optional B. cereus "
+            "typing outputs."
+        ),
+        "methods": [
+            "Long reads were classified with Kraken2 against the configured standard-8 database.",
+            "Long-read assemblies were generated with Autocycler and Flye, then polished with short reads when hybrid assembly was enabled.",
+            "Final isolate assemblies were evaluated with CheckM2 to estimate completeness and contamination.",
+            "Assemblies were annotated with Bakta, and optional BTyper3 typing was run from the Bakta genome FASTA output.",
+        ],
+        "accent": "#2563eb",
+    },
 }
 
 
@@ -101,7 +116,7 @@ TYPE_LABELS = [
     ("assembly", "Assembly files", lambda p: p.name.endswith((".fasta", ".fasta.gz", ".fa", ".fa.gz", ".fna", ".fna.gz", ".gfa", ".gfa.gz"))),
     ("mapping", "Mapping and coverage", lambda p: p.name.endswith((".bam", ".bai", ".coverage.txt")) or "coverage" in p.name.lower()),
     ("binning", "Binning outputs", lambda p: any(x in p.name.lower() for x in ["bin", "semibin", "dastool", "iterative", "checkm2", "completeness"])),
-    ("annotation", "Annotation outputs", lambda p: p.name.endswith((".gff", ".gbff", ".embl", ".faa", ".ffn")) or "bakta" in p.name.lower()),
+    ("annotation", "Annotation outputs", lambda p: p.name.endswith((".gff", ".gff3", ".gbff", ".embl", ".faa", ".ffn")) or "bakta" in p.name.lower()),
     ("visual", "Visual reports and images", lambda p: p.name.endswith((".html", ".png", ".svg"))),
     ("versions", "Software version files", lambda p: p.name == "versions.yml" or p.name.endswith("_versions.yml")),
 ]
@@ -632,8 +647,11 @@ def checkm2_rows(files: list[Path]) -> list[dict[str, str]]:
 
 
 def mag_quality_section(files: list[Path], workflow: str) -> str:
-    if workflow != "assembly_mags":
+    if workflow not in {"assembly_mags", "isolate_analysis"}:
         return ""
+    is_isolate = workflow == "isolate_analysis"
+    entity_label = "assembly" if is_isolate else "bin"
+    entity_label_title = "Assembly" if is_isolate else "Bin"
     rows = checkm2_rows(files)
     body = ""
     contig_lengths = []
@@ -697,11 +715,13 @@ def mag_quality_section(files: list[Path], workflow: str) -> str:
                 quality_label,
             ])
         body += (
-            "<p>MAG quality summaries use CheckM2 completeness and contamination estimates. "
-            f"This run staged {len(rows)} evaluated bins, including {high_quality} high-quality "
-            f"bins (at least 90% complete and at most 5% contamination), {medium_quality} "
-            "medium-quality bins (at least 50% complete and at most 10% contamination), and "
-            f"{low_quality} lower-quality bins.</p>"
+            "<p>Quality summaries use CheckM2 completeness and contamination estimates. "
+            f"This run staged {len(rows)} evaluated {entity_label}{'' if len(rows) == 1 else 's'}, including "
+            f"{high_quality} high-quality {entity_label}{'' if high_quality == 1 else 's'} "
+            f"(at least 90% complete and at most 5% contamination), {medium_quality} "
+            f"medium-quality {entity_label}{'' if medium_quality == 1 else 's'} "
+            "(at least 50% complete and at most 10% contamination), and "
+            f"{low_quality} lower-quality {entity_label}{'' if low_quality == 1 else 's'}.</p>"
         )
         body += horizontal_bar_svg(
             [
@@ -709,18 +729,18 @@ def mag_quality_section(files: list[Path], workflow: str) -> str:
                 ("Medium-quality", medium_quality),
                 ("Lower-quality", low_quality),
             ],
-            "MAG quality class counts",
+            f"{entity_label_title} quality class counts",
         )
-        body += horizontal_bar_svg(sorted(chart_values, key=lambda item: item[1], reverse=True), "MAG completeness estimates", value_suffix="%")
+        body += horizontal_bar_svg(sorted(chart_values, key=lambda item: item[1], reverse=True), f"{entity_label_title} completeness estimates", value_suffix="%")
         body += histogram_svg([value for _name, value in chart_values], "Completeness distribution", value_suffix="%")
         if contamination_values:
             body += horizontal_bar_svg(
                 sorted(contamination_values, key=lambda item: item[1], reverse=True),
-                "MAG contamination estimates",
+                f"{entity_label_title} contamination estimates",
                 value_suffix="%",
             )
             body += scatter_svg(scatter_points, "Completeness versus contamination", "Completeness (%)", "Contamination (%)")
-        body += table_html(["Bin", "Completeness", "Contamination", "Quality class"], table_rows[:20], max_cols=4)
+        body += table_html([entity_label_title, "Completeness", "Contamination", "Quality class"], table_rows[:20], max_cols=4)
     coverage_values = list(contig_coverages)
     for path in files:
         if "coverage" not in path.name.lower() or path.suffix.lower() not in {".txt", ".tsv", ".csv"}:
@@ -853,7 +873,8 @@ def image_previews(files: list[Path]) -> list[tuple[str, str]]:
     for path in files:
         if path.suffix.lower() not in {".png", ".svg"}:
             continue
-        if file_size(path) > 800_000:
+        size_limit = 5_000_000 if path.suffix.lower() == ".png" else 800_000
+        if file_size(path) > size_limit:
             continue
         mime = mimetypes.guess_type(path.name)[0] or "image/png"
         try:
@@ -996,7 +1017,8 @@ def main() -> int:
 
     mag_figures = mag_quality_section(files, args.workflow)
     if mag_figures:
-        sections.append(section("MAG Quality And Coverage Overview", mag_figures))
+        quality_title = "Assembly Quality Overview" if args.workflow == "isolate_analysis" else "MAG Quality And Coverage Overview"
+        sections.append(section(quality_title, mag_figures))
 
     preview_blocks = []
     for path, preview, stats in table_previews(files):

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -130,6 +130,11 @@ process {
         storeDir = params.bakta_db
     }
 
+    // kraken2 standard-8
+    withName: 'KRAKEN2_STANDARD8_DOWNLOAD_DB' {
+        storeDir = params.kraken2_standard8_db
+    }
+
     // singlem
     withName: 'SINGLEM_DOWNLOAD_DB' {
         storeDir = params.singlem_db
@@ -202,6 +207,10 @@ process {
         conda = 'bioconda::bakta=1.12.0' // updated from nf-core's v1.10.4
         cpus =   { 10    * task.attempt } // increased from process_medium's cpus of 6
         memory = { 16.GB * task.attempt } // reduced from process_medium's memory of 36 GB
+        ext.args = [
+            params.bakta_skip_sorf ? "--skip-sorf" : "",
+            params.bakta_args ?: "",
+        ].join(' ').trim()
     }
 
     // Incorporating non resource arguments from commented out versions below

--- a/modules/local/bakta/bakta/main.nf
+++ b/modules/local/bakta/bakta/main.nf
@@ -13,7 +13,7 @@ process BAKTA_BAKTA {
         params.analysis_type == "isolate-analysis"
             ? "${params.output_dir}/isolate_analysis/${meta.id}/annotation/bakta"
             : "${params.output_dir}/annotation/${meta.sample_id}/${meta.id}"
-    }, mode: 'copy', pattern: "*.{embl,faa,ffn,fna,gbff,gff,tsv,txt,json,png,svg}"
+    }, mode: 'copy', pattern: "*.{embl,faa,ffn,fna,gbff,gff,gff3,tsv,txt,json,png,svg}"
 
     input:
     tuple val(meta), path(fasta)
@@ -27,7 +27,7 @@ process BAKTA_BAKTA {
     tuple val(meta), path("*.ffn")            , emit: ffn
     tuple val(meta), path("*.fna")            , emit: fna
     tuple val(meta), path("*.gbff")           , emit: gbff
-    tuple val(meta), path("*.gff")            , emit: gff
+    tuple val(meta), path("*.gff3")           , emit: gff
     tuple val(meta), path("*.hypotheticals.tsv"), emit: hypotheticals_tsv
     tuple val(meta), path("*.hypotheticals.faa"), emit: hypotheticals_faa
     tuple val(meta), path("*.tsv")            , emit: tsv
@@ -48,6 +48,9 @@ process BAKTA_BAKTA {
     def prefix = fasta_name.replaceAll(/\.(fa|fasta|fna)(\.gz)?$/, '')
     
     """
+    mkdir -p .matplotlib
+    export MPLCONFIGDIR="\${PWD}/.matplotlib"
+
     # Check if FASTA file is valid and not empty
     if [ ! -s "${fasta}" ]; then
         echo "ERROR: Input FASTA file is empty or does not exist"
@@ -87,7 +90,7 @@ process BAKTA_BAKTA {
         "${prefix}.ffn"
         "${prefix}.fna"
         "${prefix}.gbff"
-        "${prefix}.gff"
+        "${prefix}.gff3"
         "${prefix}.hypotheticals.tsv"
         "${prefix}.hypotheticals.faa"
         "${prefix}.tsv"
@@ -136,7 +139,7 @@ process BAKTA_BAKTA {
     fi
     
     # Final check - ensure all output files exist
-    all_outputs="${prefix}.embl ${prefix}.faa ${prefix}.ffn ${prefix}.fna ${prefix}.gbff ${prefix}.gff ${prefix}.hypotheticals.tsv ${prefix}.hypotheticals.faa ${prefix}.tsv ${prefix}.txt ${prefix}.inference.tsv ${prefix}.png ${prefix}.svg ${prefix}.json"
+    all_outputs="${prefix}.embl ${prefix}.faa ${prefix}.ffn ${prefix}.fna ${prefix}.gbff ${prefix}.gff3 ${prefix}.hypotheticals.tsv ${prefix}.hypotheticals.faa ${prefix}.tsv ${prefix}.txt ${prefix}.inference.tsv ${prefix}.png ${prefix}.svg ${prefix}.json"
     
     for file in \$all_outputs; do
         if [ ! -f "\$file" ]; then
@@ -160,7 +163,7 @@ process BAKTA_BAKTA {
     touch ${prefix}.ffn
     touch ${prefix}.fna
     touch ${prefix}.gbff
-    touch ${prefix}.gff
+    touch ${prefix}.gff3
     touch ${prefix}.hypotheticals.tsv
     touch ${prefix}.hypotheticals.faa
     touch ${prefix}.tsv

--- a/modules/local/btyper3/main.nf
+++ b/modules/local/btyper3/main.nf
@@ -6,13 +6,14 @@ process BTYPER3 {
 
     publishDir { "${params.outdir}/isolate_analysis/${meta.id}/typing/btyper3" },
         mode: params.publish_dir_mode,
-        pattern: "btyper3_out/**"
+        pattern: "*.txt"
 
     input:
     tuple val(meta), path(fasta)
 
     output:
     tuple val(meta), path("btyper3_out"), emit: outdir
+    tuple val(meta), path("*.txt")     , emit: results
     path "versions.yml"                , emit: versions
 
     when:
@@ -26,6 +27,8 @@ process BTYPER3 {
         -o btyper3_out \\
         ${args}
 
+    find btyper3_out/btyper3_final_results -type f -name "*.txt" -exec cp {} . \\;
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         btyper3: \$(btyper3 --version 2>&1 | sed 's/^.*BTyper3 //; s/^btyper3 //; s/ .*\$//')
@@ -36,6 +39,7 @@ process BTYPER3 {
     """
     mkdir -p btyper3_out
     touch btyper3_out/btyper3_stub_results.txt
+    touch btyper3_stub_results.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/kraken2/download_db/environment.yml
+++ b/modules/local/kraken2/download_db/environment.yml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::aria2=1.37.0

--- a/modules/local/kraken2/download_db/main.nf
+++ b/modules/local/kraken2/download_db/main.nf
@@ -1,0 +1,60 @@
+process KRAKEN2_STANDARD8_DOWNLOAD_DB {
+    tag 'kraken2_standard8_download_db'
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/95/95c0d3d867f5bc805b926b08ee761a993b24062739743eb82cc56363e0f7817d/data' :
+        'community.wave.seqera.io/library/aria2:1.37.0--3a9ec328469995dd' }"
+
+    output:
+    path "k2_standard_08_GB_20260226", emit: db
+    path "versions.yml"              , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def db_url = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08_GB_20260226.tar.gz'
+    def db_archive = db_url.tokenize('/')[-1]
+    def db_dir = db_archive.replaceFirst(/\.tar\.gz$/, '')
+    """
+    aria2c \\
+        $args \\
+        --out ${db_archive} \\
+        ${db_url}
+
+    mkdir -p ${db_dir} db_tmp
+    tar -xzf ${db_archive} -C db_tmp
+
+    if [ -f db_tmp/hash.k2d ]; then
+        mv db_tmp/* ${db_dir}/
+    else
+        extracted_db_dir=\$(find db_tmp -name hash.k2d -printf '%h\\n' | head -n 1)
+        if [ -z "\${extracted_db_dir}" ]; then
+            echo "Could not find hash.k2d in extracted Kraken2 database archive" >&2
+            exit 1
+        fi
+        mv "\${extracted_db_dir}"/* ${db_dir}/
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        aria2: \$(echo \$(aria2c --version 2>&1) | grep 'aria2 version' | cut -f3 -d ' ')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    mkdir -p k2_standard_08_GB_20260226
+    touch k2_standard_08_GB_20260226/hash.k2d
+    touch k2_standard_08_GB_20260226/opts.k2d
+    touch k2_standard_08_GB_20260226/taxo.k2d
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        aria2: "stub"
+    END_VERSIONS
+    """
+}

--- a/modules/local/kraken2/download_db/tests/main.nf.test
+++ b/modules/local/kraken2/download_db/tests/main.nf.test
@@ -1,0 +1,33 @@
+nextflow_process {
+
+    name "Test Process KRAKEN2_STANDARD8_DOWNLOAD_DB"
+    script "../main.nf"
+    process "KRAKEN2_STANDARD8_DOWNLOAD_DB"
+
+    tag "modules"
+    tag "kraken2"
+    tag "kraken2/download_db"
+
+    test("Kraken2 standard-8 database download - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.db.get(0)).exists() },
+                { assert path(process.out.db.get(0).toString() + "/hash.k2d").exists() },
+                { assert path(process.out.db.get(0).toString() + "/opts.k2d").exists() },
+                { assert path(process.out.db.get(0).toString() + "/taxo.k2d").exists() },
+                { assert path(process.out.versions.get(0)).exists() }
+            )
+        }
+    }
+}

--- a/modules/local/polypolish/filter/main.nf
+++ b/modules/local/polypolish/filter/main.nf
@@ -6,13 +6,13 @@ process POLYPOLISH_FILTER {
 
     publishDir { "${params.outdir}/isolate_analysis/${meta.id}/polishing/polypolish" },
         mode: params.publish_dir_mode,
-        pattern: "*.{sam,fasta}"
+        pattern: "*.sam"
 
     input:
-    tuple val(meta), path(assembly), path(alignments_1), path(alignments_2)
+    tuple val(meta), path(alignments_1), path(alignments_2)
 
     output:
-    tuple val(meta), path("*.for_polypolish.fasta"), path("*.filtered_1.sam"), path("*.filtered_2.sam"), emit: alignments
+    tuple val(meta), path("*.filtered_1.sam"), path("*.filtered_2.sam"), emit: alignments
     path "versions.yml", emit: versions
 
     when:
@@ -28,8 +28,6 @@ process POLYPOLISH_FILTER {
         --out1 ${prefix}.filtered_1.sam \\
         --out2 ${prefix}.filtered_2.sam \\
         ${filter_args}
-
-    cp ${assembly} ${prefix}.for_polypolish.fasta
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bakta/baktadbdownload/main.nf
+++ b/modules/nf-core/bakta/baktadbdownload/main.nf
@@ -17,9 +17,11 @@ process BAKTA_BAKTADBDOWNLOAD {
 
     script:
     def args = task.ext.args ?: ''
+    def db_type = (args =~ /(^|\s)--type(\s|=|$)/).find() ? '' : '--type light'
     """
     bakta_db \\
         download \\
+        $db_type \\
         $args
 
     cat <<-END_VERSIONS > versions.yml
@@ -30,9 +32,11 @@ process BAKTA_BAKTADBDOWNLOAD {
 
     stub:
     def args = task.ext.args ?: ''
+    def db_type = (args =~ /(^|\s)--type(\s|=|$)/).find() ? '' : '--type light'
     """
     echo "bakta_db \\
         download \\
+        $db_type \\
         $args"
 
     mkdir db

--- a/modules/nf-core/checkm2/predict/main.nf
+++ b/modules/nf-core/checkm2/predict/main.nf
@@ -4,8 +4,16 @@ process CHECKM2_PREDICT {
     label 'process_medium'
 
     // Outputs
-    publishDir { "${params.output_dir}/quality/${meta.id}" }, mode: 'copy', pattern: "*.tsv"
-    publishDir { "${params.output_dir}/quality/${meta.id}/checkm2_output" }, mode: 'copy', pattern: "*/**"
+    publishDir {
+        params.analysis_type == "isolate-analysis"
+            ? "${params.output_dir}/isolate_analysis/${meta.id}/quality/checkm2"
+            : "${params.output_dir}/quality/${meta.id}"
+    }, mode: 'copy', pattern: "*.tsv"
+    publishDir {
+        params.analysis_type == "isolate-analysis"
+            ? "${params.output_dir}/isolate_analysis/${meta.id}/quality/checkm2/checkm2_output"
+            : "${params.output_dir}/quality/${meta.id}/checkm2_output"
+    }, mode: 'copy', pattern: "*/**"
 
     conda "${moduleDir}/environment.yml"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,6 +91,7 @@ params {
     // Ensemble species detection (unified DBs for Ganon, Kraken2 and Sylph)
     ganon_db                   = "${params.unified_db_base_dir}/ganon2_abvf_030325/" // Ganon2 database
     kraken2_db                 = "${params.unified_db_base_dir}/k2_abfv_030325/" // Kraken2 database
+    kraken2_standard8_db       = "${params.db_base_dir}/kraken2_standard8_db/"
     kraken2_save_output_fastqs = false
     kraken2_save_reads_assignment = true
     sylph_db                   = "${params.unified_db_base_dir}/sylph_abf_030325/database.syldb" // Sylph database
@@ -111,6 +112,8 @@ params {
 
     // bakta
     bakta_db                   = "${params.db_base_dir}/bakta_db/" 
+    bakta_skip_sorf            = params.analysis_type == "isolate-analysis"
+    bakta_args                 = ''
 
     // singlem
     singlem_db                 = "${params.db_base_dir}/singlem_db/"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -190,6 +190,10 @@
             "type": "string",
             "default": "/home/Users/pacbio_bakeoff/data/ref_db/refseq03032025/k2_abfv_030325/"
         },
+        "kraken2_standard8_db": {
+            "type": "string",
+            "default": "/home/dbs/kraken2_standard8_db/"
+        },
         "sylph_db": {
             "type": "string",
             "default": "/home/Users/pacbio_bakeoff/data/ref_db/refseq03032025/sylph_abf_030325/database.syldb"
@@ -221,6 +225,13 @@
         "bakta_db": {
             "type": "string",
             "default": "/home/dbs/bakta_db/"
+        },
+        "bakta_skip_sorf": {
+            "type": "boolean"
+        },
+        "bakta_args": {
+            "type": "string",
+            "default": ""
         },
         "singlem_db": {
             "type": "string",

--- a/subworkflows/local/download_databases.nf
+++ b/subworkflows/local/download_databases.nf
@@ -3,6 +3,7 @@
 include { HOSTILE_FETCH } from '../../modules/nf-core/hostile/fetch/main.nf'
 include { CHECKM2_DATABASEDOWNLOAD } from '../../modules/nf-core/checkm2/databasedownload/main'   
 include { BAKTA_BAKTADBDOWNLOAD } from '../../modules/nf-core/bakta/baktadbdownload/main' 
+include { KRAKEN2_STANDARD8_DOWNLOAD_DB } from '../../modules/local/kraken2/download_db/main.nf'
 include { SINGLEM_DOWNLOAD_DB } from '../../modules/local/singlem/download_db/main.nf'
 include { EMU_DOWNLOAD_DB ; EMU_STAGE_DB } from "../../modules/local/emu/download_db/main.nf"
 include { LEMUR_DATABASEDOWNLOAD ; LEMUR_STAGE_DB } from "../../modules/local/lemur/download_db/main.nf"
@@ -24,6 +25,7 @@ workflow DOWNLOAD_DBS {
     ch_lemur_db = channel.empty()
     ch_checkm2_db = channel.empty()
     ch_bakta_db = channel.empty()
+    ch_kraken2_db = channel.empty()
     ch_singlem_db = channel.empty()
 
     // log message: downloading databases for which analysis type
@@ -34,7 +36,7 @@ workflow DOWNLOAD_DBS {
     // pre-processing databases 
     // ------------------------------------------------
 
-    if (params.run_hostile) {
+    if (params.run_hostile && analysis_type != "isolate-analysis") {
         db_name_without_extension = hostile_index.replaceAll('\\.mmi$', '')
 
         // TODO: move this log message to the process itself
@@ -72,9 +74,15 @@ workflow DOWNLOAD_DBS {
     // ------------------------------------------------
     if (analysis_type == "assembly" || analysis_type == "isolate-analysis") {
         // download checkm2 database 
-        if (analysis_type == "assembly") {
+        if (analysis_type == "assembly" || analysis_type == "isolate-analysis") {
             CHECKM2_DATABASEDOWNLOAD(checkm2_db_zenodo_id)
             ch_checkm2_db = CHECKM2_DATABASEDOWNLOAD.out.database
+        }
+
+        // download Kraken2 standard-8 database for isolate read classification
+        if (analysis_type == "isolate-analysis") {
+            KRAKEN2_STANDARD8_DOWNLOAD_DB()
+            ch_kraken2_db = KRAKEN2_STANDARD8_DOWNLOAD_DB.out.db
         }
     
         // download bakta db
@@ -99,5 +107,6 @@ workflow DOWNLOAD_DBS {
     // assembly databases
     ch_checkm2_db = ch_checkm2_db
     ch_bakta_db = ch_bakta_db
+    ch_kraken2_db = ch_kraken2_db
     ch_singlem_db = ch_singlem_db
 }

--- a/subworkflows/local/isolate_analysis.nf
+++ b/subworkflows/local/isolate_analysis.nf
@@ -44,6 +44,7 @@ include { FASTA_FINALIZE }         from '../../modules/local/fasta/finalize/main
 include { KRAKEN2_KRAKEN2 }        from '../../modules/nf-core/kraken2/kraken2/main'
 include { BAKTA_BAKTA }            from '../../modules/local/bakta/bakta/main'
 include { BTYPER3 }                from '../../modules/local/btyper3/main'
+include { CHECKM2_PREDICT }        from '../../modules/nf-core/checkm2/predict/main'
 include { SOMATEM_SUMMARY_REPORT as ISOLATE_ANALYSIS_SUMMARY_REPORT } from '../../modules/local/somatem_summary_report/main.nf'
 
 workflow ISOLATE_ANALYSIS {
@@ -52,6 +53,7 @@ workflow ISOLATE_ANALYSIS {
     ch_reads
     ch_bakta_db
     ch_kraken2_db
+    ch_checkm2_db
     // tuple val(meta), path(long_reads), path(short_reads_1), path(short_reads_2),
     //       val(expected_genome_size), val(species)
 
@@ -167,10 +169,28 @@ workflow ISOLATE_ANALYSIS {
         BWA_MEM_FOR_POLYPOLISH(ch_autocycler_with_short_reads)
         ch_versions = ch_versions.mix(BWA_MEM_FOR_POLYPOLISH.out.versions)
 
-        POLYPOLISH_FILTER(BWA_MEM_FOR_POLYPOLISH.out.alignments)
+        ch_polypolish_filter_input = BWA_MEM_FOR_POLYPOLISH.out.alignments.map { meta, assembly, alignments_1, alignments_2 ->
+            tuple(meta, alignments_1, alignments_2)
+        }
+
+        POLYPOLISH_FILTER(ch_polypolish_filter_input)
         ch_versions = ch_versions.mix(POLYPOLISH_FILTER.out.versions)
 
-        POLYPOLISH_POLISH(POLYPOLISH_FILTER.out.alignments)
+        ch_polypolish_assembly = BWA_MEM_FOR_POLYPOLISH.out.alignments.map { meta, assembly, alignments_1, alignments_2 ->
+            tuple(meta.id, meta, assembly)
+        }
+
+        ch_polypolish_filtered_alignments = POLYPOLISH_FILTER.out.alignments.map { meta, filtered_1, filtered_2 ->
+            tuple(meta.id, meta, filtered_1, filtered_2)
+        }
+
+        ch_polypolish_polish_input = ch_polypolish_assembly
+            .join(ch_polypolish_filtered_alignments, by: 0)
+            .map { sample_id, meta, assembly, filter_meta, filtered_1, filtered_2 ->
+                tuple(meta, assembly, filtered_1, filtered_2)
+            }
+
+        POLYPOLISH_POLISH(ch_polypolish_polish_input)
         ch_versions = ch_versions.mix(POLYPOLISH_POLISH.out.versions)
         ch_polished_assembly = POLYPOLISH_POLISH.out.assembly
     }
@@ -209,6 +229,9 @@ workflow ISOLATE_ANALYSIS {
     FASTA_FINALIZE(ch_final_candidate_assembly)
     ch_versions = ch_versions.mix(FASTA_FINALIZE.out.versions)
 
+    CHECKM2_PREDICT(FASTA_FINALIZE.out.assembly, ch_checkm2_db)
+    ch_versions = ch_versions.mix(CHECKM2_PREDICT.out.versions)
+
     ch_bakta_input = FASTA_FINALIZE.out.assembly.map { meta, assembly ->
         def bakta_meta = meta.sample_id == null ? meta + [sample_id: meta.id] : meta
         tuple(bakta_meta, assembly)
@@ -220,9 +243,9 @@ workflow ISOLATE_ANALYSIS {
     if (run_btyper3) {
         BTYPER3(BAKTA_BAKTA.out.fna)
         ch_versions = ch_versions.mix(BTYPER3.out.versions)
-        ch_btyper3_outdir = BTYPER3.out.outdir
+        ch_btyper3_results = BTYPER3.out.results
     } else {
-        ch_btyper3_outdir = channel.empty()
+        ch_btyper3_results = channel.empty()
     }
 
     ch_versions_for_report = ch_versions
@@ -234,7 +257,8 @@ workflow ISOLATE_ANALYSIS {
             BAKTA_BAKTA.out.tsv,
             BAKTA_BAKTA.out.json,
             BAKTA_BAKTA.out.png,
-            ch_btyper3_outdir,
+            CHECKM2_PREDICT.out.checkm2_tsv,
+            ch_btyper3_results,
             ch_versions_for_report
         )
 
@@ -264,7 +288,8 @@ workflow ISOLATE_ANALYSIS {
     bakta_tsv            = BAKTA_BAKTA.out.tsv
     bakta_json           = BAKTA_BAKTA.out.json
     bakta_gff            = BAKTA_BAKTA.out.gff
-    btyper3_outdir       = ch_btyper3_outdir
+    checkm2_tsv          = CHECKM2_PREDICT.out.checkm2_tsv
+    btyper3_results      = ch_btyper3_results
     summary_report       = ISOLATE_ANALYSIS_SUMMARY_REPORT.out.html
     versions             = ch_versions
 }

--- a/subworkflows/local/utils_nfcore_somatem_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_somatem_pipeline/main.nf
@@ -60,13 +60,48 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input
     //
     // Convert samplesheet to channel
-    channel
-        .fromList(samplesheetToList(params.input, "assets/schema_input.json"))
-        .map { meta, fastq ->
-            def new_meta = meta + [single_end: true]
-            [new_meta, [fastq]]
-        }
-        .set { ch_samplesheet }
+    if (params.analysis_type == "isolate-analysis") {
+        channel
+            .fromPath(params.input, checkIfExists: true)
+            .splitCsv(header: true)
+            .map { row ->
+                def sample = row.sample?.toString()?.trim()
+                def long_reads = row.long_reads?.toString()?.trim()
+                def short_reads_1 = row.short_reads_1?.toString()?.trim()
+                def short_reads_2 = row.short_reads_2?.toString()?.trim()
+                def expected_genome_size = row.expected_genome_size?.toString()?.trim() ?: ''
+                def species = row.species?.toString()?.trim() ?: ''
+
+                if (!sample) {
+                    error("Isolate samplesheet row is missing required field: sample")
+                }
+                if (!long_reads) {
+                    error("Isolate samplesheet row for sample '${sample}' is missing required field: long_reads")
+                }
+                if ((short_reads_1 && !short_reads_2) || (!short_reads_1 && short_reads_2)) {
+                    error("Isolate samplesheet row for sample '${sample}' must provide both short_reads_1 and short_reads_2, or neither")
+                }
+
+                def meta = [id: sample, single_end: true]
+                tuple(
+                    meta,
+                    file(long_reads, checkIfExists: true),
+                    short_reads_1 ? file(short_reads_1, checkIfExists: true) : '',
+                    short_reads_2 ? file(short_reads_2, checkIfExists: true) : '',
+                    expected_genome_size,
+                    species
+                )
+            }
+            .set { ch_samplesheet }
+    } else {
+        channel
+            .fromList(samplesheetToList(params.input, "assets/schema_input.json"))
+            .map { meta, fastq ->
+                def new_meta = meta + [single_end: true]
+                [new_meta, [fastq]]
+            }
+            .set { ch_samplesheet }
+    }
 
         // Count and display all input files
         ch_samplesheet.count().view { count -> "Found ${count} samples to process" }

--- a/workflows/somatem.nf
+++ b/workflows/somatem.nf
@@ -38,16 +38,22 @@ workflow SOMATEM {
     // Pre-processing and quality control on raw reads
     // -----------------------------------------------------------------
     contam_ref = Channel.value([]) // empty channel for now
-    PREPROCESSING(ch_samplesheet, DOWNLOAD_DBS.out.ch_hostile_db, contam_ref)
-    ch_versions = ch_versions.mix(PREPROCESSING.out.versions)
-    ch_summary_reports = PREPROCESSING.out.summary_report
+    if (params.analysis_type == "isolate-analysis") {
+        ch_clean_reads = ch_samplesheet
+        ch_summary_reports = Channel.empty()
+    } else {
+        PREPROCESSING(ch_samplesheet, DOWNLOAD_DBS.out.ch_hostile_db, contam_ref)
+        ch_versions = ch_versions.mix(PREPROCESSING.out.versions)
+        ch_clean_reads = PREPROCESSING.out.clean_reads
+        ch_summary_reports = PREPROCESSING.out.summary_report
+    }
 
     // -----------------------------------------------------------------
     // Taxonomic profiling
     // -----------------------------------------------------------------
     
     if (params.analysis_type == "taxonomic-profiling") {
-        TAXONOMIC_PROFILING(PREPROCESSING.out.clean_reads, DOWNLOAD_DBS.out.ch_lemur_db)
+        TAXONOMIC_PROFILING(ch_clean_reads, DOWNLOAD_DBS.out.ch_lemur_db)
         ch_versions = ch_versions.mix(TAXONOMIC_PROFILING.out.versions)
         
         ch_key_outputs = ch_key_outputs.mix(TAXONOMIC_PROFILING.out.taxonomy_report)
@@ -64,7 +70,7 @@ workflow SOMATEM {
         ch_bakta_db = DOWNLOAD_DBS.out.ch_bakta_db
         ch_singlem_db = DOWNLOAD_DBS.out.ch_singlem_db
 
-        ASSEMBLY_MAGS(PREPROCESSING.out.clean_reads, 
+        ASSEMBLY_MAGS(ch_clean_reads, 
                 ch_checkm2_db,
                 ch_bakta_db,
                 ch_singlem_db
@@ -82,20 +88,23 @@ workflow SOMATEM {
     if (params.analysis_type == "isolate-analysis") {
 
         ch_bakta_db = DOWNLOAD_DBS.out.ch_bakta_db
-        ch_kraken2_db = Channel.value(file(params.kraken2_db))
+        ch_kraken2_db = DOWNLOAD_DBS.out.ch_kraken2_db
+        ch_checkm2_db = DOWNLOAD_DBS.out.ch_checkm2_db.map { _meta, db -> db }
 
         ISOLATE_ANALYSIS(
-            PREPROCESSING.out.clean_reads,
+            ch_clean_reads,
             ch_bakta_db,
-            ch_kraken2_db
+            ch_kraken2_db,
+            ch_checkm2_db
         )
         ch_versions = ch_versions.mix(ISOLATE_ANALYSIS.out.versions)
         ch_key_outputs = ch_key_outputs.mix(
             ISOLATE_ANALYSIS.out.assembly,
             ISOLATE_ANALYSIS.out.kraken2_report,
-            ISOLATE_ANALYSIS.out.bakta_tsv
+            ISOLATE_ANALYSIS.out.bakta_tsv,
+            ISOLATE_ANALYSIS.out.checkm2_tsv
         )
-        ch_key_outputs = ch_key_outputs.mix(ISOLATE_ANALYSIS.out.btyper3_outdir)
+        ch_key_outputs = ch_key_outputs.mix(ISOLATE_ANALYSIS.out.btyper3_results)
         ch_summary_reports = ch_summary_reports.mix(ISOLATE_ANALYSIS.out.summary_report)
     }
 
@@ -103,7 +112,7 @@ workflow SOMATEM {
     // genome dynamics : Longitudinal analysis
     // -----------------------------------------------------------------
     if (params.analysis_type == "genome-dynamics") {
-        GENOME_DYNAMICS(PREPROCESSING.out.clean_reads)
+        GENOME_DYNAMICS(ch_clean_reads)
         ch_versions = ch_versions.mix(GENOME_DYNAMICS.out.versions)
         ch_key_outputs = ch_key_outputs.mix(GENOME_DYNAMICS.out.assembly_graph)
         ch_summary_reports = ch_summary_reports.mix(GENOME_DYNAMICS.out.summary_report)
@@ -123,7 +132,7 @@ workflow SOMATEM {
 
     emit:
     versions       = ch_versions                 // channel: [ path(versions.yml) ]
-    clean_reads    = PREPROCESSING.out.clean_reads
+    clean_reads    = ch_clean_reads
     summary_reports = ch_summary_reports
     key_outputs    = ch_key_outputs              // channel: [ path(taxonomy_report.tsv) | path(assembly_graph.gfa), path(bandage_image.png) ]
     


### PR DESCRIPTION
Fixes and updates isolate_analysis.nf. Tested the hybrid assembly with the fastqs from [this paper.](https://journals.asm.org/doi/10.1128/mra.00544-23) Will be available in the example data on google drive / osf soon. With only the flye assembly currently I was able to run this on my OLD personal PC and we obtained checkm2 scores of 100% completeness with 0.02% contam!

The updates to the isolate pipeline include:
- Adds automatic download/reuse of the Kraken2 standard-8 database for isolate analysis.
- Uses the Bakta light database by default.
- Fixes Polypolish module wiring to match the documented Polypolish workflow.
- Adds CheckM2 evaluation for finalized isolate assemblies.
- Fixes BTyper3 publishing so result text files are emitted and included in reports.
- Improves Bakta handling by skipping the crashing sORF/DIAMOND step for isolate runs and using Bakta’s real .gff3 output.
- Updates the isolate summary report with isolate-specific copy, CheckM2 quality summaries, BTyper3 results, and embedded Bakta plots.