### PR TITLE
prep bioconda release workflow for v0.8.0

### DIFF
--- a/assets/scripts/prep_bioconda_dev_test.sh
+++ b/assets/scripts/prep_bioconda_dev_test.sh
@@ -1,38 +1,105 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Better method/ field standard: test on a local build (do before pushing to bioconda)
-# runs the full build.sh in an isolated environment and 
-# lets you catch substitution/path bugs before pushing to bioconda CI.
-# This saves a lot of iteration time on slow CI queues.
+usage() {
+    cat <<'USAGE'
+Usage:
+  prep_bioconda_dev_test.sh --prefix CONDA_PREFIX [options]
 
-# conda build ~/somatem/recipes/somatem/
+Refreshes an installed somatem conda package with the local wrapper script.
+Optionally replaces the installed pipeline directory with a symlink to this
+checkout for quick recipe/debug testing.
 
+Options:
+  --prefix PATH      Conda environment prefix that contains somatem
+  --version VERSION  Installed somatem package version (default: recipe version)
+  --repo PATH        Local somatem checkout (default: git repo root)
+  --link-source      Symlink share/somatem-VERSION to the local checkout
+  -h, --help         Show this help message
 
-# ------------------------------------------------------------------
-# Use this quick way to test your changes made to the github repo in the bioconda environment
-# Author: Windsurf SWE 1.5 fast
+Example:
+  assets/scripts/prep_bioconda_dev_test.sh --prefix "$CONDA_PREFIX" --link-source
+USAGE
+}
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+version=""
+prefix="${CONDA_PREFIX:-}"
+link_source=0
 
-name="somatem"
-version="0.7.1"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix)
+            prefix="$2"
+            shift 2
+            ;;
+        --version)
+            version="$2"
+            shift 2
+            ;;
+        --repo)
+            repo_root="$2"
+            shift 2
+            ;;
+        --link-source)
+            link_source=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
 
-# Copy your updated executable file and update the path to the pipeline directory
-cp ~/somatem/bin/somatem ~/micromamba/envs/somatem/bin/somatem
-sed -i "s|@@PIPELINE_DIR@@|/home/Users/pbk1/micromamba/envs/somatem/share/${name}-${version}|g" ~/micromamba/envs/somatem/bin/somatem
+if [[ -z "${version}" ]]; then
+    version="$(sed -n 's/{% set version = "\(.*\)" %}/\1/p' "${repo_root}/recipes/somatem/meta.yaml" 2>/dev/null || true)"
+fi
 
-# make it executable 
-chmod +x ~/micromamba/envs/somatem/bin/somatem
+if [[ -z "${prefix}" ]]; then
+    echo "No conda prefix provided. Use --prefix or activate the target environment." >&2
+    exit 1
+fi
 
-# Logs
-echo "Updated somatem executable at ~/micromamba/envs/somatem/bin/somatem"
-echo "Updated @@PIPELINE_DIR@@ to /home/Users/pbk1/micromamba/envs/somatem/share/${name}-${version}"
+if [[ -z "${version}" ]]; then
+    echo "Could not determine somatem version. Use --version." >&2
+    exit 1
+fi
 
+bin_dir="${prefix}/bin"
+pipeline_dir="${prefix}/share/somatem-${version}"
+wrapper="${bin_dir}/somatem"
 
-# --------------------------------------------------------
-# Then symlink the directory for your other changes
-# NOTE: This script runs only once for each version of the pipeline to make the symlink and backup
-# Comment this out after running once
-# --------------------------------------------------------
-# cd ~/micromamba/envs/somatem/share/
-# mv ${name}-${version} ${name}-${version}.original_backup
-# ln -s ~/somatem ${name}-${version}
+if [[ ! -f "${repo_root}/bin/somatem" ]]; then
+    echo "Local wrapper not found: ${repo_root}/bin/somatem" >&2
+    exit 1
+fi
+
+mkdir -p "${bin_dir}"
+cp "${repo_root}/bin/somatem" "${wrapper}"
+sed -i "s|@@PIPELINE_DIR@@|${pipeline_dir}|g" "${wrapper}"
+chmod +x "${wrapper}"
+
+if [[ "${link_source}" -eq 1 ]]; then
+    mkdir -p "$(dirname "${pipeline_dir}")"
+    if [[ -e "${pipeline_dir}" && ! -L "${pipeline_dir}" ]]; then
+        backup="${pipeline_dir}.original_backup"
+        if [[ ! -e "${backup}" ]]; then
+            mv "${pipeline_dir}" "${backup}"
+        else
+            echo "Backup already exists: ${backup}" >&2
+            exit 1
+        fi
+    elif [[ -L "${pipeline_dir}" ]]; then
+        rm "${pipeline_dir}"
+    fi
+    ln -s "${repo_root}" "${pipeline_dir}"
+fi
+
+echo "Updated ${wrapper}"
+echo "Pipeline directory: ${pipeline_dir}"

--- a/assets/scripts/update_bioconda_recipe.sh
+++ b/assets/scripts/update_bioconda_recipe.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  update_bioconda_recipe.sh VERSION [options]
+
+Updates recipes/somatem/meta.yaml for a tagged GitHub release and fills in the
+sha256 from the GitHub-generated source tarball.
+
+Options:
+  --recipe PATH       Recipe meta.yaml to update (default: recipes/somatem/meta.yaml)
+  --repo OWNER/REPO   GitHub repository (default: treangenlab/somatem)
+  --tag-prefix TEXT   Tag prefix (default: v)
+  -h, --help          Show this help message
+
+Example:
+  assets/scripts/update_bioconda_recipe.sh 0.8.0
+USAGE
+}
+
+if [[ $# -eq 0 ]]; then
+    usage >&2
+    exit 1
+fi
+
+case "$1" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+version="$1"
+shift
+
+recipe="recipes/somatem/meta.yaml"
+repo="treangenlab/somatem"
+tag_prefix="v"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --recipe)
+            recipe="$2"
+            shift 2
+            ;;
+        --repo)
+            repo="$2"
+            shift 2
+            ;;
+        --tag-prefix)
+            tag_prefix="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! "${version}" =~ ^[0-9]+([.][0-9]+)*([._-]?(a|b|rc|dev|post)[0-9]*)?$ ]]; then
+    echo "Version '${version}' does not look like a conda package version." >&2
+    exit 1
+fi
+
+if [[ ! -f "${recipe}" ]]; then
+    echo "Recipe not found: ${recipe}" >&2
+    exit 1
+fi
+
+for exe in awk curl perl sha256sum; do
+    if ! command -v "${exe}" >/dev/null 2>&1; then
+        echo "Required command not found: ${exe}" >&2
+        exit 1
+    fi
+done
+
+tag="${tag_prefix}${version}"
+url="https://github.com/${repo}/archive/refs/tags/${tag}.tar.gz"
+recipe_url="https://github.com/${repo}/archive/refs/tags/${tag_prefix}{{ version }}.tar.gz"
+tmpdir="$(mktemp -d)"
+archive="${tmpdir}/somatem-${tag}.tar.gz"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+echo "Downloading ${url}"
+curl -fsSL "${url}" -o "${archive}"
+sha256="$(sha256sum "${archive}" | awk '{print $1}')"
+
+perl -0pi -e 's/{% set version = "[^"]+" %}/{% set version = "'"${version}"'" %}/' "${recipe}"
+perl -0pi -e 's#url: https://github\.com/[^/]+/[^/]+/archive/refs/tags/[^\s]+\.tar\.gz#url: '"${recipe_url}"'#' "${recipe}"
+perl -0pi -e 's/sha256: [A-Za-z0-9_]+/sha256: '"${sha256}"'/' "${recipe}"
+
+echo "Updated ${recipe}"
+echo "  version: ${version}"
+echo "  tag:     ${tag}"
+echo "  sha256:  ${sha256}"

--- a/docs/bioconda_release.md
+++ b/docs/bioconda_release.md
@@ -1,0 +1,113 @@
+# Bioconda Release Checklist
+
+This repo keeps a mirror of the Bioconda recipe in `recipes/somatem/`. The
+canonical recipe that Bioconda builds lives in `bioconda/bioconda-recipes`, but
+keeping this copy current makes release prep easier to review before opening a
+Bioconda PR.
+
+## Release Conventions
+
+- Use the lowercase upstream repository URL: `https://github.com/treangenlab/somatem`.
+- Tag upstream releases as `vX.Y.Z`, for example `v0.8.0`.
+- Keep the conda package version numeric, for example `0.8.0`.
+- For a new upstream version, keep `build:number` at `0`.
+- Only bump `build:number` for recipe-only rebuilds of the same upstream version.
+
+## 1. Prepare the Somatem Release
+
+Update the release version in `nextflow.config` and commit the release changes.
+The public tag must exist before the recipe checksum can be finalized, because
+Bioconda verifies the checksum of GitHub's generated source tarball.
+
+```bash
+git tag -a v0.8.0 -m "somatem v0.8.0"
+git push origin main
+git push origin v0.8.0
+```
+
+## 2. Update This Repo's Recipe Copy
+
+After the tag is available on GitHub, update the local recipe copy and checksum:
+
+```bash
+assets/scripts/update_bioconda_recipe.sh 0.8.0
+```
+
+Review the recipe diff:
+
+```bash
+git diff recipes/somatem/meta.yaml recipes/somatem/build.sh
+```
+
+The recipe should point at:
+
+```yaml
+source:
+  url: https://github.com/treangenlab/somatem/archive/refs/tags/v{{ version }}.tar.gz
+```
+
+## 3. Test the Recipe Locally
+
+For a quick conda-build smoke test from this repo:
+
+```bash
+conda build recipes/somatem/
+```
+
+For the closer Bioconda test, work from a fork of `bioconda-recipes`:
+
+```bash
+git checkout master
+git pull upstream master
+git checkout -b update-somatem-0.8.0
+cp /path/to/somatem/recipes/somatem/meta.yaml recipes/somatem/meta.yaml
+cp /path/to/somatem/recipes/somatem/build.sh recipes/somatem/build.sh
+bioconda-utils lint --packages somatem
+bioconda-utils build --docker --mulled-build-and-test --packages somatem
+```
+
+If Docker is not available, run the non-Docker build first and let Bioconda CI
+run the mulled test after the PR is opened:
+
+```bash
+bioconda-utils build --packages somatem
+```
+
+## 4. Open the Bioconda PR
+
+In your `bioconda-recipes` fork:
+
+```bash
+git status
+git add recipes/somatem/meta.yaml recipes/somatem/build.sh
+git commit -m "Update somatem to 0.8.0"
+git push origin update-somatem-0.8.0
+```
+
+Open a pull request from your fork to `bioconda:master`. In the PR description,
+include:
+
+- Upstream release tag: `https://github.com/treangenlab/somatem/releases/tag/v0.8.0`
+- Local tests run, for example `bioconda-utils lint --packages somatem`
+- Any intentional recipe changes, especially dependency or wrapper-script changes
+
+After CI passes, ask for the review label if needed:
+
+```text
+@BiocondaBot please add label
+```
+
+## Local Installed-Package Debugging
+
+To test local wrapper changes inside an existing installed somatem conda
+environment:
+
+```bash
+assets/scripts/prep_bioconda_dev_test.sh --prefix "$CONDA_PREFIX"
+```
+
+To point that installed package at this checkout while debugging:
+
+```bash
+assets/scripts/prep_bioconda_dev_test.sh --prefix "$CONDA_PREFIX" --link-source
+```

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ nextflow.enable.dsl = 2
 manifest {
     name            = 'somatem'
     description     = 'A best practices pipeline for long-read metagenomic analysis'
-    version         = '1.0.0'
+    version         = '0.8.0'
     nextflowVersion = '>=25.10.2'
     homePage        = 'https://github.com/treangenlab/somatem'
     mainScript      = 'workflows/main.nf'
@@ -438,7 +438,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '>=25.10.2'
-    version         = '1.0.0dev'
+    version         = '0.8.0'
     doi             = ''
 }
 

--- a/recipes/somatem/build.sh
+++ b/recipes/somatem/build.sh
@@ -1,35 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get the path of the conda package within the conda environment
-# $PREFIX = path of the conda environment: conda install --prefix <path> somatem
 PIPELINE_DIR="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
 
-mkdir -p "${PREFIX}/bin"
-mkdir -p "${PIPELINE_DIR}"
+pipeline_dirs=(
+    assets
+    bin
+    conf
+    docs
+    modules
+    subworkflows
+    tests
+    workflows
+)
 
-# copy pipeline executable
+pipeline_files=(
+    CITATIONS.md
+    LICENSE
+    README.md
+    main.nf
+    modules.json
+    nextflow.config
+    nf-test.config
+)
+
+mkdir -p "${PREFIX}/bin" "${PIPELINE_DIR}"
+
 cp bin/somatem "${PREFIX}/bin/${PKG_NAME}"
 chmod +x "${PREFIX}/bin/${PKG_NAME}"
 
-# substitute placeholder with actual pipeline directory in the executable file
 sed -i "s|@@PIPELINE_DIR@@|${PIPELINE_DIR}|g" "${PREFIX}/bin/${PKG_NAME}"
 
-# copy pipeline directories
-cp -r assets "${PIPELINE_DIR}/"
-cp -r bin "${PIPELINE_DIR}/"
-cp -r conf "${PIPELINE_DIR}/"
-cp -r docs "${PIPELINE_DIR}/"
-cp -r modules "${PIPELINE_DIR}/"
-cp -r subworkflows "${PIPELINE_DIR}/"
-cp -r workflows "${PIPELINE_DIR}/"
-cp -r tests "${PIPELINE_DIR}/"
+for dir in "${pipeline_dirs[@]}"; do
+    cp -r "${dir}" "${PIPELINE_DIR}/"
+done
 
-# copy pipeline files
-cp CITATIONS.md "${PIPELINE_DIR}/"
-cp LICENSE "${PIPELINE_DIR}/"
-cp README.md "${PIPELINE_DIR}/"
-cp main.nf "${PIPELINE_DIR}/"
-cp modules.json "${PIPELINE_DIR}/"
-cp nextflow.config "${PIPELINE_DIR}/"
-cp nf-test.config "${PIPELINE_DIR}/"
+for file in "${pipeline_files[@]}"; do
+    cp "${file}" "${PIPELINE_DIR}/"
+done

--- a/recipes/somatem/meta.yaml
+++ b/recipes/somatem/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "somatem" %}
-{% set version = "0.7.1" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/treangenlab/Somatem/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 32a4efe92ea1fa6ec89bd873c533ee15b6898d7b7991b648c8b17507059fad20
+  url: https://github.com/treangenlab/somatem/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: TODO_REPLACE_WITH_V0_8_0_TARBALL_SHA256
 
 build:
   noarch: generic
@@ -28,16 +28,22 @@ test:
     - test -f "${PREFIX}/bin/{{ name }}"
 
 about:
-  home: https://github.com/treangenlab/Somatem
+  home: https://github.com/treangenlab/somatem
   summary: "Best practices pipeline for long-read metagenomics analysis."
   license: GPL-3.0
   license_file: LICENSE
-  dev_url: https://github.com/treangenlab/Somatem
-  doc_url: https://github.com/treangenlab/Somatem#readme
+  dev_url: https://github.com/treangenlab/somatem
+  doc_url: https://github.com/treangenlab/somatem#readme
 
 extra:
+  notes: |
+    Somatem installs a wrapper command that launches bundled Nextflow workflows from
+    $PREFIX/share/{{ name }}-{{ version }}. Use `somatem --help` to see supported
+    workflow shortcuts and common arguments.
+  watch:
+    enable: true
   skip-lints:
-    - missing_run_exports  # Top-level Nextflow application package, not intended as a pinned downstream library dependency
+    - missing_run_exports
   recipe-maintainers:
     - ppreshant
     - microbemarsh


### PR DESCRIPTION
Updates the Somatem Bioconda recipe for the upcoming v0.8.0 release.

- Switches the recipe source URL to the canonical lowercase repo: treangenlab/somatem.
- Standardizes release packaging around v{{ version }} GitHub tags.
- Adds helper scripts and docs to make future Bioconda recipe updates/checksum refreshes easier.
- Refactors the recipe build.sh file-copy logic for easier maintenance.